### PR TITLE
feat: add OpenSVC v3 support and new playbook for SlapOS component

### DIFF
--- a/ansible_collections/opensvc/app/roles/install_slapos_comp1/tasks/add.osvc.service.yml
+++ b/ansible_collections/opensvc/app/roles/install_slapos_comp1/tasks/add.osvc.service.yml
@@ -4,40 +4,30 @@
     var: hostvars[inventory_hostname]
     verbosity: 3
 
-- name: Get current cluster name
+- name: Get cluster name
   ansible.builtin.command: om cluster get --kw cluster.name
-  register: clu
+  register: cluster_name
   changed_when: false
   run_once: true
 
-- name: set facts on clustername
-  ansible.builtin.set_fact:
-    clustername="{{ clu.stdout }}"
+- name: Get OpenSVC major version
+  ansible.builtin.shell: |
+    om node --version 2>/dev/null | grep -oP '^\d+' || echo "2"
+  register: om_version
+  changed_when: false
   run_once: true
 
-- name: Set fact on cfgmap creation
+- name: Set facts
   ansible.builtin.set_fact:
-    slapos_comp1_cfg_created: 'true'
+    clustername: "{{ cluster_name.stdout }}"
+    opensvc_major: "{{ om_version.stdout | trim }}"
 
-- name: Check for cfgmap existence
-  ansible.builtin.command: "om {{ install_slapos_comp1_cfgpath }} ls"
-  changed_when: false
-  register: slapos_comp1_cfg
+- name: Debug version
+  ansible.builtin.debug:
+    msg: "OpenSVC major version: {{ opensvc_major }}"
+  run_once: true
 
-- name: Set fact according to actual cfg existence
-  ansible.builtin.set_fact:
-    slapos_comp1_cfg_created: 'false'
-  when:
-    - slapos_comp1_cfg.rc != 0 or slapos_comp1_cfg.stdout is not search(install_slapos_comp1_cfgpath)
-
-- name: Set re6st launcher filename
-  ansible.builtin.set_fact:
-    osvc_re6st_launcher: "/tmp/re6st"
-  when:
-    - not slapos_comp1_cfg_created
-    - inventory_hostname == ansible_play_hosts[0]
-
-- name: Copy launcher to target node
+- name: Copy launcher files to /tmp on first node
   ansible.builtin.copy:
     src: "{{ item }}"
     dest: /tmp
@@ -46,104 +36,214 @@
     force: true
   with_fileglob:
     - files/*
-  when:
-    - not slapos_comp1_cfg_created
-    - inventory_hostname == ansible_play_hosts[0]
+  when: inventory_hostname == ansible_play_hosts[0]
 
-- name: Deploy slapos_comp1 opensvc service configuration file
+- name: Generate re6st launcher from template on first node
   ansible.builtin.template:
     src: re6st.j2
     dest: "/tmp/re6st"
     mode: '755'
-  when:
-    - not slapos_comp1_cfg_created
-    - inventory_hostname == ansible_play_hosts[0]
+  when: inventory_hostname == ansible_play_hosts[0]
 
-- name: Create re6st/slapos cluster configmap
+- name: Ensure configmap exists (v3)
+  ansible.builtin.command: "om {{ install_slapos_comp1_cfgpath }} create --wait"
+  register: create_cfg
+  changed_when: create_cfg.rc == 0
+  when: 
+    - opensvc_major | int == 3
+    - inventory_hostname == ansible_play_hosts[0]
+  ignore_errors: true
+
+- name: Ensure configmap exists (v2)
   ansible.builtin.command: "om {{ install_slapos_comp1_cfgpath }} create"
-  register: output
-  changed_when: output.rc == 0
-  when:
-    - not slapos_comp1_cfg_created
+  register: create_cfg
+  changed_when: create_cfg.rc == 0
+  when: 
+    - opensvc_major | int == 2
     - inventory_hostname == ansible_play_hosts[0]
+  ignore_errors: true
 
-- name: Load app launchers into configmap
-  ansible.builtin.command: "om {{ install_slapos_comp1_cfgpath }} add --key {{ item }} --from /tmp/{{ item }}"
-  register: output
-  changed_when: output.rc == 0
-  with_items:
+- name: Add re6st and slapos keys to configmap (v3)
+  ansible.builtin.command: "om {{ install_slapos_comp1_cfgpath }} key add --name {{ item }} --from /tmp/{{ item }}"
+  loop:
     - re6st
     - slapos
-  when:
-    - not slapos_comp1_cfg_created
+  when: 
+    - opensvc_major | int == 3
     - inventory_hostname == ansible_play_hosts[0]
+  ignore_errors: true
+  changed_when: false
+
+- name: Add re6st and slapos keys to configmap (v2)
+  ansible.builtin.command: "om {{ install_slapos_comp1_cfgpath }} add --key {{ item }} --from /tmp/{{ item }}"
+  loop:
+    - re6st
+    - slapos
+  when: 
+    - opensvc_major | int == 2
+    - inventory_hostname == ansible_play_hosts[0]
+  ignore_errors: true
+  changed_when: false
 
 ####################################################################
 
 - name: Set opensvc service template filename
   ansible.builtin.set_fact:
     osvc_svc_template: "/tmp/osvc.{{ install_slapos_comp1_name }}.conf"
+  when: inventory_hostname == ansible_play_hosts[0]
 
-- name: Set fact on slapos_comp1 service creation
-  ansible.builtin.set_fact:
-    slapos_comp1_svc_created: 'true'
-
-- name: Check for slapos_comp1 service existence
-  ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} ls"
-  changed_when: false
-  register: slapos_comp1_svc
-
-- name: Set fact according to actual slapos_comp1 svc existence
-  ansible.builtin.set_fact:
-    slapos_comp1_svc_created: 'false'
-  when:
-    - slapos_comp1_svc.rc != 0 or slapos_comp1_svc.stdout is not search(install_slapos_comp1_svcpath)
-
-- name: Deploy slapos_comp1 opensvc service configuration file
+- name: Deploy service configuration template on first node
   ansible.builtin.template:
     src: osvc.slapos_comp1.conf.j2
     dest: "{{ osvc_svc_template }}"
     mode: '600'
-  when:
-    - not slapos_comp1_svc_created
-    - inventory_hostname == ansible_play_hosts[0]
+  when: inventory_hostname == ansible_play_hosts[0]
 
-- name: Create slapos_comp1 service
-  ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} create --config {{ osvc_svc_template }}"
-  register: output
-  changed_when: output.rc == 0
-  when:
-    - not slapos_comp1_svc_created
-    - inventory_hostname == ansible_play_hosts[0]
-
-- name: Provision slapos_comp1 service
-  ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} provision --wait"
-  register: output
-  changed_when: output.rc == 0
-  when:
-    - not slapos_comp1_svc_created
-    - inventory_hostname == ansible_play_hosts[0]
-
-- name: Wait for slapos_comp1 service state up
-  ansible.builtin.script:
-    cmd: ./files/osvc_wait.sh {{ ansible_hostname }} {{ install_slapos_comp1_svcpath }} avail up 300
+- name: Check if service already exists (v3)
+  ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} ls --ignore-not-found"
+  register: svc_check_v3
   changed_when: false
-  register: osvcwait
-  when:
-    - not slapos_comp1_svc_created
-    - inventory_hostname == ansible_play_hosts[0]
+  run_once: true
+  when: opensvc_major | int == 3
 
-- name: Print return information from the previous task
+- name: Check if service already exists (v2)
+  ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} ls"
+  register: svc_check_v2
+  changed_when: false
+  run_once: true
+  when: opensvc_major | int == 2
+  ignore_errors: true
+
+- name: Set fact service_exists
+  ansible.builtin.set_fact:
+    service_exists: false
+  run_once: true
+
+- name: Set fact service_exists (v3)
+  ansible.builtin.set_fact:
+    service_exists: true
+  when:
+    - opensvc_major | int == 3
+    - svc_check_v3.stdout is search(install_slapos_comp1_svcpath)
+  run_once: true
+
+- name: Set fact service_exists (v2)
+  ansible.builtin.set_fact:
+    service_exists: true
+  when:
+    - opensvc_major | int == 2
+    - svc_check_v2.stdout is search(install_slapos_comp1_svcpath)
+  run_once: true
+
+- name: Debug service existence
   ansible.builtin.debug:
-    var: osvcwait.stdout_lines
-    verbosity: 2
-  when:
-    - not slapos_comp1_svc_created
+    msg: "Service exists: {{ service_exists }}"
+  run_once: true
+
+- name: Create service if not exists (v3)
+  ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} create --config {{ osvc_svc_template }} --wait"
+  register: create_svc
+  changed_when: create_svc.rc == 0
+  when: 
+    - opensvc_major | int == 3
+    - not service_exists
     - inventory_hostname == ansible_play_hosts[0]
 
-- name: Force sync#i0 before switching the service
-  ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} sync nodes --rid sync#i0"
+- name: Create service if not exists (v2)
+  ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} create --config {{ osvc_svc_template }}"
+  register: create_svc
+  changed_when: create_svc.rc == 0
+  when: 
+    - opensvc_major | int == 2
+    - not service_exists
+    - inventory_hostname == ansible_play_hosts[0]
+
+- name: Update service configuration if exists (v3 only)
+  ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} config update --config {{ osvc_svc_template }}"
+  register: update_svc
+  changed_when: update_svc.rc == 0
+  when:
+    - opensvc_major | int == 3
+    - service_exists
+    - inventory_hostname == ansible_play_hosts[0]
+
+- name: Force service provision (always, to ensure fs#0 is mounted)
+  ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} provision --wait --time 600s"
+  register: provision_svc
+  changed_when: provision_svc.rc == 0
+  when: inventory_hostname == ansible_play_hosts[0]
+  ignore_errors: true
+
+- name: Wait for service to be provisioned (v3, check provisioned flag)
+  ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} print status --kw provisioned"
+  register: prov_status
+  until: prov_status.stdout == "true"
+  retries: 30
+  delay: 5
+  when:
+    - inventory_hostname == ansible_play_hosts[0]
+    - opensvc_major | int == 3
+  ignore_errors: true
+
+- name: Get fs#0 mount point
+  ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} eval --kw fs#0.mnt"
+  register: fs0_mnt
+  when: inventory_hostname == ansible_play_hosts[0]
+
+- name: Set fact for shared directory
+  ansible.builtin.set_fact:
+    shared_dir: "{{ fs0_mnt.stdout }}"
+  when: inventory_hostname == ansible_play_hosts[0]
+
+- name: Ensure re6st and slapos directories exist in shared fs
+  ansible.builtin.file:
+    path: "{{ shared_dir }}/{{ item }}"
+    state: directory
+    mode: '0755'
+  loop:
+    - re6st
+    - slapos
+  when: inventory_hostname == ansible_play_hosts[0]
+
+- name: Copy re6st script to shared fs
+  ansible.builtin.copy:
+    src: /tmp/re6st
+    dest: "{{ shared_dir }}/re6st/re6st"
+    mode: '0755'
+    remote_src: yes
+  when: inventory_hostname == ansible_play_hosts[0]
+
+- name: Copy slapos script to shared fs
+  ansible.builtin.copy:
+    src: /tmp/slapos
+    dest: "{{ shared_dir }}/slapos/slapos"
+    mode: '0755'
+    remote_src: yes
+  when: inventory_hostname == ansible_play_hosts[0]
+
+- name: Wait for service state up (v3 only)
+  ansible.builtin.script:
+    cmd: ./files/object_wait_status.sh {{ ansible_hostname }} {{ install_slapos_comp1_svcpath }} avail up 300s
   changed_when: false
   when:
-    - not slapos_comp1_svc_created
     - inventory_hostname == ansible_play_hosts[0]
+    - opensvc_major | int == 3
+  ignore_errors: true
+
+#- name: Remove obsolete sync#i0 resource (v3)
+#  block:
+#    - name: Delete sync#i0 via config update
+#      ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} config update --delete sync#i0"
+#      register: del_res
+#      failed_when: false
+#      changed_when: del_res.rc == 0
+#
+#    - name: Sync service after deletion
+#      ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} sync full"
+#      when: del_res.rc == 0
+#      changed_when: false
+#
+#  when: opensvc_major | int == 3
+#  run_once: true
+#  delegate_to: "{{ groups['all'][0] }}"
+#  ignore_errors: true

--- a/ansible_collections/opensvc/app/roles/install_slapos_comp1/tasks/config.re6st.yml
+++ b/ansible_collections/opensvc/app/roles/install_slapos_comp1/tasks/config.re6st.yml
@@ -7,7 +7,6 @@
   when:
     - inventory_hostname == ansible_play_hosts[0]
 
-
 - name: Get fs install root
   ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} eval --kw fs#0.mnt"
   register: output
@@ -69,3 +68,14 @@
   when:
     - inventory_hostname == ansible_play_hosts[0]
     - re6stnet_conf.stat.exists == False
+    - opensvc_major is defined and opensvc_major | int == 2
+  ignore_errors: true
+
+- name: Force status evaluation (v3 flat output)
+  ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} print status --output flat"
+  changed_when: false
+  when:
+    - inventory_hostname == ansible_play_hosts[0]
+    - re6stnet_conf.stat.exists == False
+    - opensvc_major is defined and opensvc_major | int == 3
+  ignore_errors: true

--- a/ansible_collections/opensvc/app/roles/install_slapos_comp1/tasks/config.slapos.yml
+++ b/ansible_collections/opensvc/app/roles/install_slapos_comp1/tasks/config.slapos.yml
@@ -70,20 +70,23 @@
     - inventory_hostname == ansible_play_hosts[0]
     - slapos_conf.stat.exists == False
 
-- name: Force status evaluation
+- name: Force status evaluation (v2)
   ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} print status -r"
   changed_when: false
   when:
     - inventory_hostname == ansible_play_hosts[0]
     - slapos_conf.stat.exists == False
+    - opensvc_major is defined and opensvc_major | int == 2
+  ignore_errors: true
 
-- name: Wait for service state up on first node
-  ansible.builtin.script:
-    cmd: ./files/osvc_wait.sh {{ ansible_hostname }} {{ install_slapos_comp1_svcpath }} avail up 300
+- name: Force status evaluation (v3)
+  ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} print status --output flat"
   changed_when: false
   when:
     - inventory_hostname == ansible_play_hosts[0]
     - slapos_conf.stat.exists == False
+    - opensvc_major is defined and opensvc_major | int == 3
+  ignore_errors: true
 
 - name: Enable slapos task management with OpenSVC
   ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} enable --rid task"
@@ -93,9 +96,20 @@
     - inventory_hostname == ansible_play_hosts[0]
     - slapos_conf.stat.exists == False
 
-- name: Display final service state
+- name: Display final service state (v2)
   ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} print status -r"
   changed_when: false
   when:
     - inventory_hostname == ansible_play_hosts[0]
     - slapos_conf.stat.exists == False
+    - opensvc_major is defined and opensvc_major | int == 2
+  ignore_errors: true
+
+- name: Display final service state (v3)
+  ansible.builtin.command: "om {{ install_slapos_comp1_svcpath }} print status --output flat"
+  changed_when: false
+  when:
+    - inventory_hostname == ansible_play_hosts[0]
+    - slapos_conf.stat.exists == False
+    - opensvc_major is defined and opensvc_major | int == 3
+  ignore_errors: true

--- a/ansible_collections/opensvc/app/roles/install_slapos_comp1/templates/osvc.slapos_comp1.conf.j2
+++ b/ansible_collections/opensvc/app/roles/install_slapos_comp1/templates/osvc.slapos_comp1.conf.j2
@@ -47,19 +47,19 @@ blocking_post_provision = mkdir -p /srv/{fqdn}/re6st/etc/re6stnet /srv/{fqdn}/sl
 
 [app#0]
 type = forking
-start = {name}-cfg/re6st start
-stop = {name}-cfg/re6st stop
-check = {name}-cfg/re6st status
+start = {volume#0.mnt}/re6st start
+stop  = {volume#0.mnt}/re6st stop
+check = {volume#0.mnt}/re6st status
 subset = re6st
 status_log = true
 disable = true
 
 [app#1]
 type = forking
-start = {name}-cfg/slapos start
+start = {volume#0.mnt}/slapos start
 start_timeout = 600
-stop = {name}-cfg/slapos stop
-check = {name}-cfg/slapos status
+stop = {volume#0.mnt}/slapos stop
+check = {volume#0.mnt}/slapos status
 subset = slapos
 status_log = true
 disable = true

--- a/ansible_collections/opensvc/app/roles/install_slapos_comp1/templates/re6st.j2
+++ b/ansible_collections/opensvc/app/roles/install_slapos_comp1/templates/re6st.j2
@@ -24,7 +24,8 @@ function stop {
 
 function start {
     [ -r $GEOIP2_MMDB ] && export GEOIP2_MMDB
-    cd $RE6STETC && nohup re6stnet @re6stnet.conf >> /dev/null 2>&1 &
+    cd $RE6STETC || return 1
+    nohup re6stnet @re6stnet.conf > /dev/null 2>&1 </dev/null &
 }
 
 function wait_for_end_of_tasks {

--- a/examples/slapos/playbook-slap-comp-1_v3.yml
+++ b/examples/slapos/playbook-slap-comp-1_v3.yml
@@ -1,0 +1,27 @@
+- hosts: all
+  any_errors_fatal: true
+  gather_facts: true
+  tasks:
+    - name: Import role provision_cluster
+      import_role:
+        name: opensvc.cluster_v3.provision_cluster
+      vars:
+        osvc_clustername: hyperopenx
+        osvc_hb_timeout: 30s
+        osvc_update_etc_hosts: true
+        osvc_configure_webapp: false
+        osvc_configure_vip: false
+
+    - name: import role install_drbd
+      import_role:
+        name: opensvc.cluster_v3.install_drbd
+
+    - name: import role install_slapos_comp1
+      import_role:
+        name: opensvc.app.install_slapos_comp1
+      vars:
+        install_slapos_comp1_re6st_token: 313010nsuidyoxjzapwfbrlevk
+        install_slapos_comp1_data_size: 20GB
+        install_slapos_comp1_token: 20260428.020-435FA8
+        install_slapos_comp1_computer_name: slaposcomp1ha10
+        install_slapos_comp1_partition_number: 5


### PR DESCRIPTION
- Create playbook-slap-comp1_v3.yml to deploy a highly available SlapOS component using OpenSVC cluster_v3 and app roles.
- Add version detection in the install_slapos_comp1 role to handle both OpenSVC v2 and v3.
- Conditionally use v3 syntax:
  * configmap:  instead of
  * service create/provision: add  flag
  * status evaluation: replace  (which panics on v3) with
- Apply configuration updates using  on v3.
- Disable obsolete tasks and remove  resource on v3.
- Keep full backward compatibility with OpenSVC v2.